### PR TITLE
sanders: Drop deprecated OpenGLRenderer Props

### DIFF
--- a/vendor_prop.mk
+++ b/vendor_prop.mk
@@ -147,19 +147,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
     ro.fm.transmitter=false \
     vendor.hw.fm.init=0
 
-# HWUI properties
-PRODUCT_PROPERTY_OVERRIDES += \
-    ro.hwui.texture_cache_size=72 \
-    ro.hwui.layer_cache_size=48 \
-    ro.hwui.r_buffer_cache_size=8 \
-    ro.hwui.path_cache_size=32 \
-    ro.hwui.gradient_cache_size=1 \
-    ro.hwui.drop_shadow_cache_size=6 \
-    ro.hwui.texture_cache_flushrate=0.4 \
-    ro.hwui.text_small_cache_width=1024 \
-    ro.hwui.text_small_cache_height=1024 \
-    ro.hwui.text_large_cache_width=2048 \
-    ro.hwui.text_large_cache_height=1024
 
 # IMS
 PRODUCT_PROPERTY_OVERRIDES += \


### PR DESCRIPTION
These are the properties that you can use to control Android’s 2D hardware accelerated rendering pipeline and were dropped after android 8.0.
Reference:https://source.android.com/devices/graphics/renderer#openglrenderer-libhwui-properties